### PR TITLE
Gateway routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Gateway routes (get_gateway, get_gateway_bot)
 
 ## [0.2.1] - 2020-8-29
 ### Added

--- a/lib/vox/http/routes/gateway.rb
+++ b/lib/vox/http/routes/gateway.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'vox/http/route'
+
+module Vox
+  module HTTP
+    module Routes
+      # Mixin for gateway routes, used for retriving information
+      # about connecting to the gateway.
+      module Gateway
+        # rubocop:disable Naming/AccessorMethodName
+
+        # Fetch the URL to use for a gateway connection.
+        # @return [Hash<:url, String>] An object with one key `url` that maps to the URL
+        #   for connecting to the gateway.
+        # @vox.api_docs https://discord.com/developers/docs/topics/gateway#get-gateway
+        def get_gateway
+          request(Route.new(:GET, '/gateway'))
+        end
+
+        # Fetch the URL to use for a gateway connection, with additional sharding information.
+        # @return [Hash{ :url => String, :shards => Integer, :session_start_limit => Hash<Symbol, Integer>}]
+        #   An object that includes the URL to connect to the gateway with, the recommended number of shards,
+        #   as well as a [session start limit](https://discord.com/developers/docs/topics/gateway#session-start-limit-object-session-start-limit-structure)
+        #   object.
+        # @vox.api_docs https://discord.com/developers/docs/topics/gateway#get-gateway-bot
+        def get_gateway_bot
+          request(Route.new(:GET, '/gateway/bot'))
+        end
+
+        # rubocop:enable Naming/AccessorMethodName
+      end
+    end
+  end
+end

--- a/spec/vox/http/routes/gateway_spec.rb
+++ b/spec/vox/http/routes/gateway_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require 'vox/http/routes/gateway'
+
+RSpec.describe Vox::HTTP::Routes::Gateway do
+  let(:client) { Class.new { include Vox::HTTP::Routes::Gateway }.new }
+
+  before do
+    stub_const('Route', Vox::HTTP::Route)
+    allow(client).to receive(:request).with(any_args)
+  end
+
+  describe '#get_gateway' do
+    it 'sends a request with no parameters' do
+      client.get_gateway
+      route = Route.new(:GET, '/gateway')
+      expect(client).to have_received(:request).with(route)
+    end
+  end
+
+  describe '#get_gateway_bot' do
+    it 'sends a request with no parameters' do
+      client.get_gateway_bot
+      route = Route.new(:GET, '/gateway/bot')
+      expect(client).to have_received(:request).with(route)
+    end
+  end
+end


### PR DESCRIPTION
Add support for gateway routes to prepare for the gateway component.

# Added
- HTTP::Routes::Gateway
- Gateway#get_gateway
- Gateway#get_gateway_bot