### PR TITLE
Add a comprehensive test option to rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,8 @@
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
+require 'yard'
+require 'yard/rake/yardoc_task'
 
 RSpec::Core::RakeTask.new(:spec) do |t|
   t.rspec_opts = '--format progress'
@@ -10,5 +12,10 @@ RSpec::Core::RakeTask.new(:spec) do |t|
 end
 
 RuboCop::RakeTask.new(:rubocop)
+
+YARD::Rake::YardocTask.new(:yard)
+
+# Run all tests
+task test: %i[rubocop yard spec]
 
 task default: :spec


### PR DESCRIPTION
Add a `test` task to the Rakefile that covers all tests suites; `rspec`, `rubocop`, and `yard`.