### PR TITLE
Deprecate the usage of a positional argument to provide the token in …

### DIFF
--- a/lib/vox/http/client.rb
+++ b/lib/vox/http/client.rb
@@ -43,7 +43,8 @@ module Vox
         'User-Agent': "DiscordBot (https://github.com/swarley/vox, #{Vox::VERSION})"
       }.freeze
 
-      def initialize(token)
+      def initialize(depr_token = nil, token: nil)
+        token ||= depr_token
         @conn = default_connection
         @conn.authorization('Bot', token.delete_prefix('Bot '))
         yield(@conn) if block_given?


### PR DESCRIPTION
Deprecate the usage of a positional argument to provide the token in HTTP::Client#initialize, it will be removed entirely in 1.0